### PR TITLE
hwcrypto/sha.h deprecated in arduino-esp32 v2

### DIFF
--- a/src/utility/WebSockets.cpp
+++ b/src/utility/WebSockets.cpp
@@ -39,7 +39,11 @@ extern "C" {
 #ifdef ESP8266
 #include <Hash.h>
 #elif defined(ESP32)
-#include <hwcrypto/sha.h>
+#ifdef ESP_ARDUINO_VERSION             // defined since arduino-esp32 v2.0.0
+#include <sha/sha_parallel_engine.h>  
+#else
+#include <hwcrypto/sha.h>              // removed in arduino-esp32 v2.0.0
+#endif
 #else
 
 extern "C" {


### PR DESCRIPTION
Resolve build issue on arduino-esp32 v2.x

https://github.com/espressif/arduino-esp32/blob/399f4ecbb3a4cef21e2bffa37adb6190356dfb76/cores/esp32/esp_arduino_version.h#L40